### PR TITLE
Pull meta from config in test result logs

### DIFF
--- a/core/dbt/parser/schema_generic_tests.py
+++ b/core/dbt/parser/schema_generic_tests.py
@@ -134,6 +134,7 @@ class SchemaGenericTestParser(SimpleParser):
             "column_name": column_name,
             "checksum": FileHash.empty().to_dict(omit_none=True),
             "file_key_name": file_key_name,
+            "meta": target.config.get('meta', {}) if hasattr(target, 'config') else {},
         }
         try:
             GenericTestNode.validate(dct)


### PR DESCRIPTION
https://oaknorth-bank.atlassian.net/browse/DATAPLAT-2522

I didn't get the whole test suite running on my machine, and neither do I want to set up CI here, but all the [unit tests](https://github.com/user-attachments/files/17117124/unit.txt) and [functional logging tests](https://github.com/user-attachments/files/17117123/functional_logging.txt) pass.