### PR TITLE
chore: add Dependabot cooldown — Python (pip), Python (pip), Docker, Docker, GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,15 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 3
     rebase-strategy: "disabled"
   - package-ecosystem: "pip"
     directory: "/core"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 3
     rebase-strategy: "disabled"
 
   # docker dependencies
@@ -17,11 +21,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3
     rebase-strategy: "disabled"
   - package-ecosystem: "docker"
     directory: "/docker"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3
     rebase-strategy: "disabled"
 
   # github dependencies
@@ -29,4 +37,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3
     rebase-strategy: "disabled"


### PR DESCRIPTION
https://www.notion.so/ADR-011-Introduce-Cooldown-Period-for-Dependency-Updates-2e37256fbc328194b407d081692279d5
https://www.notion.so/Safe-deployment-guardrails-for-SDLC-controls-rollout-3507256fbc3280368c22fc45fe65b8dd

Adds a **3-day cooldown** to Dependabot dependency updates for **Python (pip), Python (pip), Docker, Docker, GitHub Actions**, as required by ADR-011.

The cooldown delays Dependabot PR creation by 3 days after a new package version is published. This provides a buffer to detect supply chain attacks or compromised releases before the organisation automatically adopts them.

**Changes made:**
- `Python (pip)`: added `cooldown: default-days: 3`
- `Python (pip)`: added `cooldown: default-days: 3`
- `Docker`: added `cooldown: default-days: 3`
- `Docker`: added `cooldown: default-days: 3`
- `GitHub Actions`: added `cooldown: default-days: 3`

**No other changes.** All existing configuration — ignore rules, groups, registry settings, schedules, and PR limits — is untouched.

**Risk classification:** `MEDIUM` — push-to-main via shared-actions (safety fix in place): structured-logging-schema-check.yml, model_performance.yml, main.yml
